### PR TITLE
add query param token auth class, authzn. checks and switch to drf API view

### DIFF
--- a/src/token_display/authentication.py
+++ b/src/token_display/authentication.py
@@ -1,0 +1,40 @@
+"""
+Custom authentication classes for token display views.
+
+This module provides authentication mechanisms that read tokens from
+query parameters instead of HTTP headers, useful for display screens
+and embedded content where header management is difficult.
+"""
+
+from rest_framework.authentication import TokenAuthentication
+
+
+class QueryParamTokenAuthentication(TokenAuthentication):
+    """
+    Token authentication that reads the token from query parameters
+    instead of the Authorization header.
+
+    Usage:
+        Add to view's authentication_classes:
+        authentication_classes = [QueryParamTokenAuthentication]
+
+    Example:
+        GET /api/display/?token=abc123def456
+    """
+
+    def authenticate(self, request):
+        """
+        Authenticate the request by reading the token from query parameters.
+
+        Returns:
+            tuple: (user, token) if authentication succeeds
+            None: if no token is provided (allows anonymous access)
+
+        Raises:
+            AuthenticationFailed: if token is invalid
+        """
+        token = request.query_params.get("token")
+        if not token:
+            return None  # No authentication attempted
+
+        return self.authenticate_credentials(token)

--- a/src/token_display/signals.py
+++ b/src/token_display/signals.py
@@ -9,9 +9,9 @@ TokenQueue changes, etc.).
 from django.core.cache import cache
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from token_display.utils import get_token_display_cache_key
 
 from care.emr.models import SchedulableResource, Token, TokenQueue, TokenSubQueue
-from token_display.utils import get_token_display_cache_key
 
 
 def invalidate_sub_queue_cache(sub_queues: list[TokenSubQueue]):

--- a/src/token_display/signals.py
+++ b/src/token_display/signals.py
@@ -7,11 +7,11 @@ TokenQueue changes, etc.).
 """
 
 from django.core.cache import cache
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
-from token_display.utils import get_token_display_cache_key
 
 from care.emr.models import SchedulableResource, Token, TokenQueue, TokenSubQueue
+from token_display.utils import get_token_display_cache_key
 
 
 def invalidate_sub_queue_cache(sub_queues: list[TokenSubQueue]):
@@ -32,20 +32,19 @@ def invalidate_resource_sub_queue_cache(resource: SchedulableResource):
 
 
 @receiver(post_save, sender=Token)
-def invalidate_token_display_cache_on_token_save(sender, instance, created, **kwargs):
-    """
-    Invalidate token display cache when a Token is saved or updated.
-    """
-    # Invalidate cache for the token's sub_queue (if it exists)
+def invalidate_token_display_cache_on_token_post_save(
+    sender, instance, created, **kwargs
+):
     if instance.sub_queue:
         invalidate_sub_queue_cache([instance.sub_queue])
-    else:
-        invalidate_resource_sub_queue_cache(instance.queue.resource)
+
+
+@receiver(pre_save, sender=Token)
+def invalidate_token_display_cache_on_token_pre_save(sender, instance, **kwargs):
+    if instance.sub_queue:
+        invalidate_sub_queue_cache([instance.sub_queue])
 
 
 @receiver(post_save, sender=TokenQueue)
 def invalidate_token_display_cache_on_queue_save(sender, instance, created, **kwargs):
-    """
-    Invalidate token display cache for all sub queues in a TokenQueue when it's updated.
-    """
     invalidate_resource_sub_queue_cache(instance.resource)

--- a/src/token_display/templates/token_display/display.html
+++ b/src/token_display/templates/token_display/display.html
@@ -163,7 +163,7 @@
     {% for sub_queue in sub_queues %}
       <div
         class="service-point-card {{ sub_queue.col_span }}"
-        hx-get="/token_display/sub_queue/{{ sub_queue.id }}/partial/?token={{ auth_token }}"
+        hx-get="/token_display/sub_queue/{{ sub_queue.id }}/partial/"
         hx-trigger="load, every {{ refresh_interval }}s"
         hx-swap="innerHTML"
         id="token-content-{{ sub_queue.id }}"

--- a/src/token_display/templates/token_display/display.html
+++ b/src/token_display/templates/token_display/display.html
@@ -163,7 +163,7 @@
     {% for sub_queue in sub_queues %}
       <div
         class="service-point-card {{ sub_queue.col_span }}"
-        hx-get="/token_display/sub_queue/{{ sub_queue.id }}/partial/"
+        hx-get="/token_display/sub_queue/{{ sub_queue.id }}/partial/?token={{ auth_token }}"
         hx-trigger="load, every {{ refresh_interval }}s"
         hx-swap="innerHTML"
         id="token-content-{{ sub_queue.id }}"

--- a/src/token_display/urls.py
+++ b/src/token_display/urls.py
@@ -1,11 +1,6 @@
 from django.shortcuts import HttpResponse
 from django.urls import path
 
-from token_display.views import (
-    SubQueuesTokenDisplayView,
-    SubQueueTokenDisplayPartialView,
-)
-
 
 def healthy(request):
     return HttpResponse("OK")

--- a/src/token_display/views.py
+++ b/src/token_display/views.py
@@ -4,6 +4,12 @@ from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
+from token_display.settings import plugin_settings
+from token_display.utils import (
+    fmt_schedule_resource_name,
+    fmt_token_number,
+    get_token_display_cache_key,
+)
 
 from care.emr.models import Token, TokenSubQueue
 from care.emr.resources.scheduling.token.spec import TokenStatusOptions
@@ -12,18 +18,6 @@ from care.emr.resources.scheduling.token_sub_queue.spec import (
 )
 from care.utils.shortcuts import get_object_or_404
 from care.utils.time_util import care_now
-from token_display.settings import plugin_settings
-from token_display.utils import (
-    fmt_schedule_resource_name,
-    fmt_token_number,
-    get_token_display_cache_key,
-)
-
-
-def authenticate_request(request: HttpRequest) -> bool:
-    from rest_framework.authtoken.models import Token as AuthToken
-
-    get_object_or_404(AuthToken, key=request.GET.get("token"))
 
 
 class SubQueuesTokenDisplayView(View):
@@ -35,7 +29,6 @@ class SubQueuesTokenDisplayView(View):
         """
         Render the full token display page with HTMX setup.
         """
-        authenticate_request(request)
         sub_queues = TokenSubQueue.objects.filter(
             external_id__in=sub_queue_external_ids.split(","),
             status=TokenSubQueueStatusOptions.active.value,
@@ -79,7 +72,6 @@ class SubQueuesTokenDisplayView(View):
             "item_count": item_count,
             "grid_class": grid_class,
             "refresh_interval": plugin_settings.TOKEN_DISPLAY_REFRESH_INTERVAL,
-            "auth_token": request.GET.get("token"),
         }
         return render(request, "token_display/display.html", context)
 
@@ -97,7 +89,6 @@ class SubQueueTokenDisplayPartialView(View):
         """
         Return the partial HTML with updated token data for a specific sub queue.
         """
-        authenticate_request(request)
         cache_key = get_token_display_cache_key(sub_queue_external_id)
         cached_html = cache.get(cache_key)
         if cached_html is not None:

--- a/src/token_display/views.py
+++ b/src/token_display/views.py
@@ -1,15 +1,9 @@
 from uuid import UUID
 
 from django.core.cache import cache
-from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
-from django.views import View
-from token_display.settings import plugin_settings
-from token_display.utils import (
-    fmt_schedule_resource_name,
-    fmt_token_number,
-    get_token_display_cache_key,
-)
+from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from care.emr.models import Token, TokenSubQueue
 from care.emr.resources.scheduling.token.spec import TokenStatusOptions
@@ -18,14 +12,25 @@ from care.emr.resources.scheduling.token_sub_queue.spec import (
 )
 from care.utils.shortcuts import get_object_or_404
 from care.utils.time_util import care_now
+from token_display.authentication import QueryParamTokenAuthentication
+from token_display.settings import plugin_settings
+from token_display.utils import (
+    fmt_schedule_resource_name,
+    fmt_token_number,
+    get_token_display_cache_key,
+)
 
 
-class SubQueuesTokenDisplayView(View):
+class SubQueuesTokenDisplayView(APIView):
     """
     Main view that renders the full SSR token display page for a facility.
     """
 
-    def get(self, request: HttpRequest, sub_queue_external_ids: str) -> HttpResponse:
+    authentication_classes = [QueryParamTokenAuthentication]
+    renderer_classes = [TemplateHTMLRenderer]
+    template_name = "token_display/display.html"
+
+    def get(self, request, sub_queue_external_ids: str):
         """
         Render the full token display page with HTMX setup.
         """
@@ -67,32 +72,34 @@ class SubQueuesTokenDisplayView(View):
                 }
             )
 
-        context = {
-            "sub_queues": sub_queues_with_spans,
-            "item_count": item_count,
-            "grid_class": grid_class,
-            "refresh_interval": plugin_settings.TOKEN_DISPLAY_REFRESH_INTERVAL,
-        }
-        return render(request, "token_display/display.html", context)
+        return Response(
+            {
+                "sub_queues": sub_queues_with_spans,
+                "item_count": item_count,
+                "grid_class": grid_class,
+                "refresh_interval": plugin_settings.TOKEN_DISPLAY_REFRESH_INTERVAL,
+                "auth_token": self.request.GET.get("token"),
+            }
+        )
 
 
-class SubQueueTokenDisplayPartialView(View):
+class SubQueueTokenDisplayPartialView(APIView):
     """
     Partial view that returns only the data portion for HTMX swapping.
     """
 
-    def get(
-        self,
-        request: HttpRequest,
-        sub_queue_external_id: UUID,
-    ) -> HttpResponse:
+    authentication_classes = [QueryParamTokenAuthentication]
+    renderer_classes = [TemplateHTMLRenderer]
+    template_name = "token_display/partial.html"
+
+    def get(self, request, sub_queue_external_id: UUID):
         """
         Return the partial HTML with updated token data for a specific sub queue.
         """
         cache_key = get_token_display_cache_key(sub_queue_external_id)
-        cached_html = cache.get(cache_key)
-        if cached_html is not None:
-            return HttpResponse(cached_html)
+        cached_context = cache.get(cache_key)
+        if cached_context is not None:
+            return Response(cached_context)
 
         sub_queue = get_object_or_404(
             TokenSubQueue,
@@ -117,11 +124,10 @@ class SubQueueTokenDisplayPartialView(View):
             "refresh_interval": plugin_settings.TOKEN_DISPLAY_REFRESH_INTERVAL,
         }
 
-        rendered_html = render(request, "token_display/partial.html", context)
         cache.set(
             cache_key,
-            rendered_html.content.decode("utf-8"),
+            context,
             plugin_settings.TOKEN_DISPLAY_CACHE_TIMEOUT,
         )
 
-        return rendered_html
+        return Response(context)


### PR DESCRIPTION
### proposed changes

- switched to DRF API View, so that we can set `authentication_classes`.
- implemented an authentication class extending the TokenAuthentication to allow token based on auth via query params
- added authzn. checks to ensure authenticated user has permission to list token on the resource.