### PR TITLE
adds support for configurable refresh interval

### DIFF
--- a/src/token_display/settings.py
+++ b/src/token_display/settings.py
@@ -99,7 +99,9 @@ class PluginSettings:  # pragma: no cover
 
 REQUIRED_SETTINGS = set()
 
-DEFAULTS = {}
+DEFAULTS = {
+    "AUTO_REFRESH_INTERVAL": 0,
+}
 
 plugin_settings = PluginSettings(
     PLUGIN_NAME, defaults=DEFAULTS, required_settings=REQUIRED_SETTINGS

--- a/src/token_display/templates/token_display/display.html
+++ b/src/token_display/templates/token_display/display.html
@@ -1,8 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {% if auto_refresh_interval %}
+    <meta http-equiv="refresh" content="{{ auto_refresh_interval }}" />
+    {% endif %}
     <title>Token Display</title>
     <style>
       * {
@@ -10,8 +13,9 @@
       }
 
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          Oxygen, Ubuntu, Cantarell, sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, sans-serif;
         margin: 0;
         padding: 0;
         background: #1fb6c9;

--- a/src/token_display/views.py
+++ b/src/token_display/views.py
@@ -13,6 +13,7 @@ from care.emr.resources.scheduling.token_sub_queue.spec import (
 from care.security.authorization import AuthorizationController
 
 from token_display.authentication import QueryParamTokenAuthentication
+from token_display.settings import plugin_settings
 from token_display.utils import (
     fmt_schedule_resource_name,
     fmt_token_number,
@@ -104,6 +105,7 @@ class SubQueuesTokenDisplayView(APIView):
             {
                 "sub_queues": sub_queues_with_data,
                 "item_count": item_count,
+                "auto_refresh_interval": plugin_settings.AUTO_REFRESH_INTERVAL,
                 "grid_class": grid_class,
             }
         )


### PR DESCRIPTION
In certain signage display servers, there are limitations to configure refresh interval in a playlist along with one that includes videos (such as ads),  as well as the token display’s content.
 
In such situations, it is preferable to instruct the client’s browser client to do the refresh instead of configuring it in the sign display.

In this PR, we allow configurable refresh interval to be set via plugin config.

The following is the configuration needed for enabling refresh every 5 seconds.
If the config is not set, the meta tag will not be included in the rendered html.

```json
"configs": {
    "AUTO_REFRESH_INTERVAL": 5
}
```