### PR TITLE
ENG-157 Show next two tokens in queue

### DIFF
--- a/src/token_display/templates/token_display/display.html
+++ b/src/token_display/templates/token_display/display.html
@@ -81,6 +81,7 @@
       .token-display-area {
         flex: 1;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         background: #07131f;
@@ -94,6 +95,47 @@
         padding: 8px 12px;
         overflow: hidden;
         text-align: center;
+      }
+
+      .upcoming-tokens {
+        background: #122235;
+        border-radius: 0 0 16px 16px;
+        padding: 12px 16px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .upcoming-tokens-label {
+        color: #9ca3af;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 12px;
+        font-weight: 700;
+        text-align: center;
+      }
+
+      .upcoming-tokens-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px;
+      }
+
+      .upcoming-token {
+        background: #07131f;
+        border-radius: 8px;
+        padding: 8px 4px;
+        color: #e5e7eb;
+        font-weight: 800;
+        font-size: 18px;
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .upcoming-token.is-empty {
+        color: #4b5563;
       }
 
       .empty-screen {
@@ -115,6 +157,15 @@
         .token-number {
           font-size: 64px;
         }
+
+        .upcoming-tokens-label {
+          font-size: 14px;
+        }
+
+        .upcoming-token {
+          font-size: 24px;
+          padding: 10px 6px;
+        }
       }
 
       @media (min-width: 768px) {
@@ -128,6 +179,15 @@
 
         .token-number {
           font-size: 96px;
+        }
+
+        .upcoming-tokens-label {
+          font-size: 16px;
+        }
+
+        .upcoming-token {
+          font-size: 32px;
+          padding: 12px 8px;
         }
       }
 
@@ -163,6 +223,19 @@
         <div class="token-display-area">
           <div class="token-number">{{ sub_queue.token }}</div>
         </div>
+        {% if sub_queue.upcoming_tokens %}
+        <div class="upcoming-tokens">
+          <div class="upcoming-tokens-label">Next in queue →</div>
+          <div class="upcoming-tokens-grid">
+            {% for upcoming in sub_queue.upcoming_tokens %}
+            <span class="upcoming-token">{{ upcoming }}</span>
+            {% endfor %}
+            {% for _ in sub_queue.upcoming_padding %}
+            <span class="upcoming-token is-empty">—</span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
       </div>
       {% endfor %}
     </div>

--- a/src/token_display/views.py
+++ b/src/token_display/views.py
@@ -155,6 +155,16 @@ class SubQueuesTokenDisplayView(APIView):
             )
 
             token_code = fmt_token_number(token) if token else None
+
+            upcoming_tokens_qs = Token.objects.filter(
+                queue__resource=sub_queue.resource,
+                queue__date=make_naive(timezone.now()).date(),
+                queue__is_primary=True,
+                sub_queue=sub_queue,
+                status=TokenStatusOptions.CREATED.value,
+            ).order_by("created_date")[:2]
+            upcoming_tokens = [fmt_token_number(t) for t in upcoming_tokens_qs]
+
             sub_queues_with_data.append(
                 {
                     "id": str(sub_queue.external_id),
@@ -163,6 +173,8 @@ class SubQueuesTokenDisplayView(APIView):
                     "resource_name": fmt_schedule_resource_name(sub_queue.resource),
                     "token": token_code or "--",
                     "token_code": token_code,
+                    "upcoming_tokens": upcoming_tokens,
+                    "upcoming_padding": range(max(0, 2 - len(upcoming_tokens))),
                 }
             )
 


### PR DESCRIPTION
Currently in the token display, we are only showing the latest in-service token.
 
We also need to show which all tokens are next. This can be achieved by querying the called (status=created) tokens of a the relevant sub-queue (service point). 

https://openhealthcarenetwork.atlassian.net/browse/ENG-157


<img width="2056" height="706" alt="image" src="https://github.com/user-attachments/assets/48a749b7-a347-4317-8f69-ba03887b9c8d" />
